### PR TITLE
Allow building with Ninja, simplify MinGW build instructions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,23 @@
+# Not all CMake Generators support file globbing, so build our tex dependency list manually
+# We could get CMake to do the glob, but there's not many files to deal with
+set(DOC_LIST
+	glscopeclient-manual.tex
+	section-decodes.tex
+	section-drivers.tex
+	section-gettingstarted.tex
+	section-history.tex
+	section-legal.tex
+	section-mainwindow.tex
+	section-protoanalyzer.tex
+	section-revision.tex
+	section-timeline.tex
+	section-transports.tex
+	section-waveformgroups.tex
+	section-waveformviews.tex
+)
+# Save ourselves from having to manually paste this in front of every filename
+list(TRANSFORM DOC_LIST PREPEND ${CMAKE_CURRENT_SOURCE_DIR}/)
+
 add_custom_command(
 	OUTPUT  ${CMAKE_CURRENT_BINARY_DIR}/glscopeclient-manual.pdf
 	COMMAND pdflatex -halt-on-error -interaction batchmode
@@ -6,7 +26,7 @@ add_custom_command(
 	COMMAND pdflatex -halt-on-error -interaction batchmode
 		--output-directory ${CMAKE_CURRENT_BINARY_DIR}
 		${CMAKE_CURRENT_SOURCE_DIR}/glscopeclient-manual.tex > /dev/null
-	DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/*.tex
+	DEPENDS ${DOC_LIST}
 	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 	VERBATIM)
 add_custom_target(doc ALL

--- a/section-gettingstarted.tex
+++ b/section-gettingstarted.tex
@@ -111,10 +111,9 @@ git clone https://github.com/anthonix/ffts.git
 cd ffts
 mkdir build
 cd build
-cmake -G"MinGW Makefiles" ../
+cmake -G"MinGW Makefiles" -DCMAKE_INSTALL_PREFIX=$MSYSTEM_PREFIX ..
 mingw32-make -j
-cp ./libffts_static.a /mingw64/lib/
-cp ./../include/ffts.h /mingw64/include/
+mingw32-make install
 \end{lstlisting}
 
 \item Build scopehal and scopehal-apps


### PR DESCRIPTION
Ninja (and probably other CMake targets) do not support file globbing, so list out the dependencies manually.
This is the recommended way of declaring dependencies/sources in CMake, as it can miss them if they don't exist when you first run CMake.

Updated install procedure for MinGW on the assumption the following pull request lands
https://github.com/azonenberg/scopehal-cmake/pull/18
The environment variable MSYSTEM_PREFIX is set to system root (/mingw64 for x86_64 and /mingw32 for i686), so it should work for all MSYS2 builds.

I also tested a Ninja build on Windows under MSYS2 MinGW, can attest that it all builds as expected.