### PR TITLE
Installation instructions error

### DIFF
--- a/section-gettingstarted.tex
+++ b/section-gettingstarted.tex
@@ -69,7 +69,7 @@ sudo apt install build-essential cmake pkg-config libglm-dev \
 
 On Fedora:
 \begin{lstlisting}[language=sh]
-sudo apt install gtkmm30-devel cmake pkg-config glm-devel \
+sudo dnf install gtkmm30-devel cmake pkg-config glm-devel \
 	texlive libyaml-devel yaml-cpp-devel glew-devel \
 	catch-devel
 \end{lstlisting}


### PR DESCRIPTION
The Fedora example uses apt, when it should be dnf.