### PR TITLE
Update Windows cmake documentation for ffts include

### DIFF
--- a/section-gettingstarted.tex
+++ b/section-gettingstarted.tex
@@ -151,7 +151,7 @@ git clone https://github.com/azonenberg/scopehal-apps.git --recurse-submodules
 cd scopehal-apps
 mkdir build
 cd build
-cmake -G"MinGW Makefiles" -DLIBFFTS_INCLUDE_DIR=/mingw64/include/ \
+cmake -G"MinGW Makefiles" -DLIBFFTS_INCLUDE_DIR=/mingw64/include/ffts \
     -DLIBFFTS_LIBRARIES=/mingw64/lib/libffts_static.a \
     -DBUILD_TESTING=OFF ..
 mingw32-make -j4


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/50162961/102704382-8b20a280-422f-11eb-8266-65f5166cc948.png)

After extending include directory:
![image](https://user-images.githubusercontent.com/50162961/102704407-b7d4ba00-422f-11eb-94cf-74ba510e92fe.png)

