### PR TITLE
A tiny patch to fix lstlisting formatting of underscores in Getting Started

### DIFF
--- a/section-gettingstarted.tex
+++ b/section-gettingstarted.tex
@@ -45,10 +45,10 @@ TODO: what AMD integrated/ARM GPUs started supporting GL 4.2?
 
 To check for necessary graphics card support on Linux:
 \begin{lstlisting}[language=sh]
-glxinfo | grep GL\_ARB\_arrays\_of\_arrays
-glxinfo | grep GL\_ARB\_compute\_shader
-glxinfo | grep GL\_ARB\_shader\_storage\_buffer\_object
-glxinfo | grep GL\_EXT\_blend\_equation\_separate
+glxinfo | grep GL_ARB_arrays_of_arrays
+glxinfo | grep GL_ARB_compute_shader
+glxinfo | grep GL_ARB_shader_storage_buffer_object
+glxinfo | grep GL_EXT_blend_equation_separate
 glxinfo | grep "OpenGL version string"
 \end{lstlisting}
 


### PR DESCRIPTION
Most of LaTeX has the annoying requirement that underscores be escaped with backslashes, but the `lstlisting` environment does not require these.  I quickly looked for other instances in the manual, but I didn't find any.