### PR TITLE
Migrate to FFTW from FFTS inside unit tests

### DIFF
--- a/section-gettingstarted.tex
+++ b/section-gettingstarted.tex
@@ -292,9 +292,9 @@ pacman -S mingw-w64-ucrt-x86_64-libsigc++ mingw-w64-ucrt-x86_64-yaml-cpp mingw-w
 pacman -S mingw-w64-ucrt-x86_64-vulkan-headers mingw-w64-ucrt-x86_64-vulkan-loader mingw-w64-ucrt-x86_64-shaderc mingw-w64-ucrt-x86_64-glslang mingw-w64-ucrt-x86_64-spirv-tools
 \end{lstlisting}
 
-\item Install FFTS:
+\item Install FFTW (required for a few unit tests):
 \begin{lstlisting}[language=sh, numbers=none]
-pacman -S mingw-w64-ucrt-x86_64-ffts
+pacman -S mingw-w64-ucrt-x86_64-fftw
 \end{lstlisting}
 
 \item Check out the code

--- a/section-legal.tex
+++ b/section-legal.tex
@@ -73,6 +73,6 @@ respective owners.
 
 \subsection{Only in unit tests}
 \begin{itemize}
-\item FFTS (shared, BSD-3) - \url{https://github.com/anthonix/ffts/blob/master/COPYRIGHT}
+\item FFTW (shared, GPLv2-or-later) - \url{https://www.fftw.org/doc/License-and-Copyright.html}
 \item catch2 (static, Boost license) - \url{https://github.com/catchorg/Catch2/blob/devel/LICENSE.txt}
 \end{itemize}


### PR DESCRIPTION
Companion PR for ngscopeclient/scopehal-apps#900

No grep results for FFTS/ffts.