### PR TITLE
TeX to HTML output: Add missing directory ng-images/filters to the call to ebb

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,7 @@ add_custom_command(
 
 	# Get bounding box data for images
 	# this is ugly and might not work on non-Linux but is better than nothing for now?
-	COMMAND sh -c "ebb -x images/*.png images/filters/*.png ng-images/*.png"
+	COMMAND sh -c "ebb -x images/*.png images/filters/*.png ng-images/*.png ng-images/filters/*.png"
 
 	# Actual building
 	COMMAND make4ht -uf html5 --output-dir ${CMAKE_CURRENT_BINARY_DIR}/html


### PR DESCRIPTION
Images in the directory ng-images/filters are displayed with incorrect aspect ratio. 
This occured because the Tex-to-HTML converter did not get information on their size, because the command to generate the size information (bounding box) was missing one location where the images were stored.

Fixes https://github.com/ngscopeclient/scopehal-docs/issues/117
