### PR TITLE
scope-drivers: MHO900/MHO98 are supported

### DIFF
--- a/section-scope-drivers.tex
+++ b/section-scope-drivers.tex
@@ -488,6 +488,8 @@ DHO900 & rigol & (no digital channels)\\
 DHO1000 & rigol & (untested)\\
 \thinhline
 DHO4000 & rigol & (untested)\\
+\thinhline
+MHO900 / MHO98 & rigol & (no digital channels)\\
 \thickhline
 \end{tabularx}
 


### PR DESCRIPTION
cc @whitequark @azonenberg 